### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cargo install dash7-tools
 For [sub-iot](https://github.com/Sub-IoT/Sub-IoT-Stack) payloads
 
 ```sh
-cargo install dash7-tools --no-default-features -F std,subiot
+cargo install dash7-tools --no-default-features -F subiot
 ```
 
 ### Usage


### PR DESCRIPTION
dash7-tools will use the std feature of dash7 by default ( no std feature defined in dash7-tools)